### PR TITLE
Only consider the first operationalState for ScsiLun objects.

### DIFF
--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -2595,6 +2595,8 @@ sub host_storage_info
 						{
 							$state = CRITICAL;
 						}
+
+						last; # the first state should be considered the primary state.
 					}
 				}
 
@@ -2729,6 +2731,8 @@ sub host_storage_info
 					$status = UNKNOWN;
 				}
 				$state = Monitoring::Plugin::Functions::max_state($state, $status);
+
+				last; # the first state should be considered the primary state.
 			}
 		}
 		$np->add_perfdata(label => "LUNs", value => $count, uom => 'units', threshold => $np->threshold);


### PR DESCRIPTION
To quote the documentation for the operationalState property:

> The operational states of the LUN. When more than one item is present in the array, the first state should be considered the primary state. For example, a LUN may be "ok" and "degraded" indicating I/O is still possible to the LUN, but it is operating in a degraded mode.

https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.host.ScsiLun.html

This prevents LUNs in `ok-degraded` state to trigger a warning:
```
$ ./check_vmware_api.pl -f <path> -H <host> -l storage --adapter_status_unknown_is_ok
CHECK_VMWARE_API.PL WARNING - 0/5 adapters online, 4/4 LUNs ok, 4/4 paths active | adapters=0units;; LUNs=4units;; paths=4units;
```
The warning was not triggered for the `lun` subcommand:
```
$ ./check_vmware_api.pl -f <file> -H <host> -l storage -s lun
CHECK_VMWARE_API.PL OK - Local HL-DT-ST CD-ROM (mpx.vmhba0:C0:T0:L0) <ok>; HP Serial Attached SCSI Disk (naa.5000c500323e5527) <ok-degraded>; LSILOGIC Serial Attached SCSI Disk (naa.600508e0000000002adfac2e84b55b09) <ok-degraded>; HP Serial Attached SCSI Disk (naa.5000c5002c7ad37b) <ok-degraded>;  | LUNs=1units;;
```