### PR TITLE
Treat unbound hostBusAdapter status as OK.

### DIFF
--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -2679,6 +2679,10 @@ sub host_storage_info
 			{
 				$status = CRITICAL;
 			}
+			elsif (uc($dev->status) eq "UNBOUND")
+			{
+				$status = OK;
+			}
 			else
 			{
 				$res = UNKNOWN;


### PR DESCRIPTION
In more recent SDK versions (e.g. 6.5) the `hostBusAdapter` object adds the `unbound` value to the list of possible `status` property values.

From [VMware vSphere 6.5 Documentation Center - VMware vSphere API Reference](http://pubs.vmware.com/vsphere-65/topic/com.vmware.wssdk.apiref.doc/vim.host.HostBusAdapter.html):

Name | Type | Description
---- | ---- | -----------
**status** | xsd:string | The operational status of the adapter. Valid values include "online", "offline", "unbound", and "unknown". 

Having an adapter in that state is not a problem that warrants a non-OK status for the check command.