### PR TITLE
Improve VMFS monitoring output: better perfdata, human-readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is how to install the plugin on CentOS with VMware vSphere SDK for Perl
 - In this example we use VMware-vSphere-Perl-SDK-5.1.0-780721.x86_64.tar.gz.
 - Make sure the following packages are installed.
 ```bash
-$ sudo yum install openssl-devel perl-Archive-Zip perl-Class-MethodMaker uuid-perl perl-SOAP-Lite perl-XML-SAX perl-XML-NamespaceSupport perl-XML-LibXML perl-MIME-Lite perl-MIME-Types perl-MailTools perl-TimeDate uuid libuuid perl-Data-Dump perl-UUID cpan libxml2-devel perl-libwww-perl perl-Test-MockObject perl-Test-Simple perl-Monitoring-Plugin perl-Class-Accessor perl-Config-Tiny
+$ sudo yum install openssl-devel perl-Archive-Zip perl-Class-MethodMaker uuid-perl perl-SOAP-Lite perl-XML-SAX perl-XML-NamespaceSupport perl-XML-LibXML perl-MIME-Lite perl-MIME-Types perl-MailTools perl-TimeDate uuid libuuid perl-Data-Dump perl-UUID cpan libxml2-devel perl-libwww-perl perl-Test-MockObject perl-Test-Simple perl-Monitoring-Plugin perl-Class-Accessor perl-Config-Tiny perl-Number-Bytes-Human
 ```
 - Upload the file "VMware-vSphere-Perl-SDK*.tar.gz" to your op5 Monitor server’s
 /root directory.

--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -1220,7 +1220,7 @@ sub datastore_volumes_info
 			{
 				$store->RefreshDatastoreStorageInfo() if ($store->can("RefreshDatastoreStorageInfo") && exists($store->info->{timestamp}) && $defperfargs->{timeshift} && (time() - str2time($store->info->timestamp) > $defperfargs->{timeshift}));
 				my $value1 = convert_number($store->summary->freeSpace);
-				my $value2 = convert_number($store->summary->capacity);
+				my $value2 = my $capacity = convert_number($store->summary->capacity);
 				$value2 = simplify_number(convert_number($store->info->freeSpace) / $value2 * 100) if ($value2 > 0);
 
 				if ($usedflag)
@@ -1231,7 +1231,7 @@ sub datastore_volumes_info
 
 				$state = $np->check_threshold(check => $perc?$value2:$value1);
 				$res = Monitoring::Plugin::Functions::max_state($res, $state);
-				$np->add_perfdata(label => $name, value => $perc?$value2:$value1, uom => $perc?'%':'B', threshold => $np->threshold);
+				$np->add_perfdata(label => $name, value => $perc?$value2:$value1, uom => $perc?'%':'B', threshold => $np->threshold, min => 0, max => $capacity);
 				$output .= "'$name'" . ($usedflag ? "(used)" : "(free)") . "=". $value1 . " B (" . $value2 . "%), " if (!$briefflag || $state != OK);
 			}
 			else

--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -1219,20 +1219,20 @@ sub datastore_volumes_info
 			if ($store->summary->accessible)
 			{
 				$store->RefreshDatastoreStorageInfo() if ($store->can("RefreshDatastoreStorageInfo") && exists($store->info->{timestamp}) && $defperfargs->{timeshift} && (time() - str2time($store->info->timestamp) > $defperfargs->{timeshift}));
-				my $value1 = simplify_number(convert_number($store->summary->freeSpace) / 1024 / 1024);
+				my $value1 = convert_number($store->summary->freeSpace);
 				my $value2 = convert_number($store->summary->capacity);
 				$value2 = simplify_number(convert_number($store->info->freeSpace) / $value2 * 100) if ($value2 > 0);
 
 				if ($usedflag)
 				{
-					$value1 = simplify_number(convert_number($store->summary->capacity) / 1024 / 1024) - $value1;
+					$value1 = convert_number($store->summary->capacity) - $value1;
 					$value2 = 100 - $value2;
 				}
 
 				$state = $np->check_threshold(check => $perc?$value2:$value1);
 				$res = Monitoring::Plugin::Functions::max_state($res, $state);
-				$np->add_perfdata(label => $name, value => $perc?$value2:$value1, uom => $perc?'%':'MB', threshold => $np->threshold);
-				$output .= "'$name'" . ($usedflag ? "(used)" : "(free)") . "=". $value1 . " MB (" . $value2 . "%), " if (!$briefflag || $state != OK);
+				$np->add_perfdata(label => $name, value => $perc?$value2:$value1, uom => $perc?'%':'B', threshold => $np->threshold);
+				$output .= "'$name'" . ($usedflag ? "(used)" : "(free)") . "=". $value1 . " B (" . $value2 . "%), " if (!$briefflag || $state != OK);
 			}
 			else
 			{

--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -42,6 +42,7 @@ use File::Basename;
 use HTTP::Date;
 use Data::Dumper qw(Dumper);
 use Net::SSL;
+use Number::Bytes::Human qw(format_bytes);
 my $perl_module_instructions="
 Download the latest version of the vSphere SDK for Perl from VMware.
 In this example we use VMware-vSphere-Perl-SDK-5.1.0-780721.x86_64.tar.gz,
@@ -1232,7 +1233,7 @@ sub datastore_volumes_info
 				$state = $np->check_threshold(check => $perc?$value2:$value1);
 				$res = Monitoring::Plugin::Functions::max_state($res, $state);
 				$np->add_perfdata(label => $name, value => $perc?$value2:$value1, uom => $perc?'%':'B', threshold => $np->threshold, min => 0, max => $capacity);
-				$output .= "'$name'" . ($usedflag ? "(used)" : "(free)") . "=". $value1 . " B (" . $value2 . "%), " if (!$briefflag || $state != OK);
+				$output .= "'$name'" . ($usedflag ? "(used)" : "(free)") . "=". format_bytes($value1) . "B/" . format_bytes($capacity) . "B (" . $value2 . "%), " if (!$briefflag || $state != OK);
 			}
 			else
 			{


### PR DESCRIPTION
Hi, since all these changes are more or less related, I decided to include them all in this PR.
The change from "MB" to "B" is required for Centreon to properly graph VMFS perf data.