### PR TITLE
Allow 0 VMs as output of LIST subcommand

### DIFF
--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -2291,7 +2291,6 @@ sub host_runtime_info
 			my %vm_state_strings = ("poweredOn" => "UP", "poweredOff" => "DOWN", "suspended" => "SUSPENDED");
 			my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $host_view, properties => ['name', 'runtime']);
 			die "Runtime error\n" if (!defined($vm_views));
-			die "There are no VMs.\n" if (!@$vm_views);
 			my $up = 0;
 			$output = '';
 


### PR DESCRIPTION
Hi,

I use the plugin to monitor the number of VMs in our cluster. During and shortly after maintenance the number of VMs is 0 which is OK as all VMs had beed migrated away due to maintenance. This is not critical, not even a warning. I therefore removed the "die" statement which checks the number of VMs in the beginning.

It is still possible to check for the existence of at least one VM by using a threshold of '1:'.

Thanks,

Christopher