### PR TITLE
Vm uom

### DIFF
--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -41,7 +41,6 @@ use Monitoring::Plugin;
 use File::Basename;
 use HTTP::Date;
 use Data::Dumper qw(Dumper);
-use Net::SSL;
 my $perl_module_instructions="
 Download the latest version of the vSphere SDK for Perl from VMware.
 In this example we use VMware-vSphere-Perl-SDK-5.1.0-780721.x86_64.tar.gz,
@@ -1445,7 +1444,6 @@ sub host_mem_info
 				{
 					my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $$host_view[0], properties => ['name', 'runtime.powerState']);
 					die "Runtime error\n" if (!defined($vm_views));
-					die "There are no VMs.\n" if (!@$vm_views);
 					my @vms = ();
 					foreach my $vm (@$vm_views)
 					{
@@ -1500,7 +1498,6 @@ sub host_mem_info
 				{
 					my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $$host_view[0], properties => ['name', 'runtime.powerState']);
 					die "Runtime error\n" if (!defined($vm_views));
-					die "There are no VMs.\n" if (!@$vm_views);
 					my @vms = ();
 					foreach my $vm (@$vm_views)
 					{
@@ -2291,7 +2288,6 @@ sub host_runtime_info
 			my %vm_state_strings = ("poweredOn" => "UP", "poweredOff" => "DOWN", "suspended" => "SUSPENDED");
 			my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $host_view, properties => ['name', 'runtime']);
 			die "Runtime error\n" if (!defined($vm_views));
-			die "There are no VMs.\n" if (!@$vm_views);
 			my $up = 0;
 			$output = '';
 
@@ -3990,7 +3986,6 @@ sub dc_runtime_info
 			my %vm_state_strings = ("poweredOn" => "UP", "poweredOff" => "DOWN", "suspended" => "SUSPENDED");
 			my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', properties => ['name', 'runtime']);
 			die "Runtime error\n" if (!defined($vm_views));
-			die "There are no VMs.\n" if (!@$vm_views);
 			my $up = 0;
 			$output = '';
 
@@ -4019,7 +4014,6 @@ sub dc_runtime_info
 			my %host_state_strings = ("unknown" => "UNKNOWN", "poweredOn" => "UP", "poweredOff" => "DOWN", "suspended" => "SUSPENDED", "standBy" => "STANDBY", "MaintenanceMode" => "Maintenance Mode");
 			my $host_views = Vim::find_entity_views(view_type => 'HostSystem', properties => ['name', 'runtime.powerState']);
 			die "Runtime error\n" if (!defined($host_views));
-			die "There are no VMs.\n" if (!@$host_views);
 			my $up = 0;
 			my $unknown = 0;
 			$output = '';
@@ -4082,7 +4076,6 @@ sub dc_runtime_info
 		{
 			my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', properties => ['name', 'runtime.powerState', 'summary.guest']);
 			die "Runtime error\n" if (!defined($vm_views));
-			die "There are no VMs.\n" if (!@$vm_views);
 			$output = '';
 			my $tools_ok = 0;
 			my $vms_up = 0;
@@ -4395,7 +4388,6 @@ sub cluster_mem_info
 				{
 					my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $$cluster_view[0], properties => ['name', 'runtime.powerState']);
 					die "Runtime error\n" if (!defined($vm_views));
-					die "There are no VMs.\n" if (!@$vm_views);
 					my @vms = ();
 					foreach my $vm (@$vm_views)
 					{
@@ -4428,7 +4420,6 @@ sub cluster_mem_info
 				{
 					my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $$cluster_view[0], properties => ['name', 'runtime.powerState']);
 					die "Runtime error\n" if (!defined($vm_views));
-					die "There are no VMs.\n" if (!@$vm_views);
 					my @vms = ();
 					foreach my $vm (@$vm_views)
 					{
@@ -4581,7 +4572,6 @@ sub cluster_runtime_info
 			my %vm_state_strings = ("poweredOn" => "UP", "poweredOff" => "DOWN", "suspended" => "SUSPENDED");
 			my $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $cluster_view, properties => ['name', 'runtime']);
 			die "Runtime error\n" if (!defined($vm_views));
-			die "There are no VMs.\n" if (!defined($vm_views));
 			my $up = 0;
 			$output = '';
 

--- a/check_vmware_api.pl
+++ b/check_vmware_api.pl
@@ -2313,7 +2313,7 @@ sub host_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $up . "/" . @$vm_views . " VMs up: " . $output;
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $up) if (defined($np->threshold));
 		}
 		elsif ($subcommand eq "STATUS")
@@ -2371,7 +2371,7 @@ sub host_runtime_info
 		{
 			$output = "No VMs installed";
 		}
-		$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+		$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 
 		my $AlertCount = 0;
 		my $SensorCount = 0;
@@ -2545,7 +2545,7 @@ sub host_storage_info
 			}
 			my $state = $np->check_threshold(check => $count);
 			$res = $state if ($state != OK);
-			$np->add_perfdata(label => "adapters", value => $count, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "adapters", value => $count, threshold => $np->threshold);
 		}
 		elsif ($subcommand eq "LUN")
 		{
@@ -2601,7 +2601,7 @@ sub host_storage_info
 				$count++ if ($state == OK);
 				$output .= $name . " <" . $operationState . ">; ";
 			}
-			$np->add_perfdata(label => "LUNs", value => $count, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "LUNs", value => $count, threshold => $np->threshold);
 			$state = $np->check_threshold(check => $count);
 			$res = $state if ($state != OK);
 		}
@@ -2641,7 +2641,7 @@ sub host_storage_info
 						$output .= $name . " <" . $pathState . ">; ";
 					}
 				}
-				$np->add_perfdata(label => "paths", value => $count, uom => 'units', threshold => $np->threshold);
+				$np->add_perfdata(label => "paths", value => $count, threshold => $np->threshold);
 				my $state = $np->check_threshold(check => $count);
 				$res = $state if ($state != OK);
 			}
@@ -2685,7 +2685,7 @@ sub host_storage_info
 			}
 			$state = Monitoring::Plugin::Functions::max_state($state, $status);
 		}
-		$np->add_perfdata(label => "adapters", value => $count, uom => 'units', threshold => $np->threshold);
+		$np->add_perfdata(label => "adapters", value => $count, threshold => $np->threshold);
 		$output .= $count . "/" . @{$storage->storageDeviceInfo->hostBusAdapter} . " adapters online, ";
 
 		$count = 0;
@@ -2731,7 +2731,7 @@ sub host_storage_info
 				$state = Monitoring::Plugin::Functions::max_state($state, $status);
 			}
 		}
-		$np->add_perfdata(label => "LUNs", value => $count, uom => 'units', threshold => $np->threshold);
+		$np->add_perfdata(label => "LUNs", value => $count, threshold => $np->threshold);
 		$output .= $count . "/" . @{$storage->storageDeviceInfo->scsiLun} . " LUNs ok, ";
 
 		if (exists($storage->storageDeviceInfo->{multipathInfo}))
@@ -2780,7 +2780,7 @@ sub host_storage_info
 					$amount++;
 				}
 			}
-			$np->add_perfdata(label => "paths", value => $count, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "paths", value => $count, threshold => $np->threshold);
 			$output .= $count . "/" . $amount . " paths active";
 		}
 		else
@@ -4011,7 +4011,7 @@ sub dc_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $up . "/" . @$vm_views . " VMs up: " . $output;
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $up) if (defined($np->threshold));
 		}
 		elsif ($subcommand eq "LISTHOST")
@@ -4042,7 +4042,7 @@ sub dc_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $up . "/" . @$host_views . " Hosts up: " . $output;
-			$np->add_perfdata(label => "hostcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "hostcount", value => $up, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $up) if (defined($np->threshold));
 			$res = UNKNOWN if ($res == OK && $unknown);
 		}
@@ -4074,7 +4074,7 @@ sub dc_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $green . "/" . @$cluster_views . " Cluster green: " . $output;
-			$np->add_perfdata(label => "clustercount", value => $green, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "clustercount", value => $green, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $green) if (defined($np->threshold));
 			$res = UNKNOWN if ($res == OK && $unknown);
 		}
@@ -4245,7 +4245,7 @@ sub dc_runtime_info
 		{
 			$output = "No VMs installed, ";
 		}
-		$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+		$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 
 		my $host_views = Vim::find_entity_views(view_type => 'HostSystem', properties => ['name', 'runtime.powerState']);
 		die "Runtime error\n" if (!defined($host_views));
@@ -4262,7 +4262,7 @@ sub dc_runtime_info
 		{
 			$output .= "there are no hosts, ";
 		}
-		$np->add_perfdata(label => "hostcount", value => $up, uom => 'units');
+		$np->add_perfdata(label => "hostcount", value => $up);
 
 		$res = OK;
 
@@ -4603,7 +4603,7 @@ sub cluster_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $up .  "/" . @$vm_views . " VMs up: " . $output;
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $up) if (defined($np->threshold));
 		}
 		elsif ($subcommand eq "LISTHOST")
@@ -4633,7 +4633,7 @@ sub cluster_runtime_info
 			chop($output);
 			$res = OK;
 			$output = $up .  "/" . @$host_views . " Hosts up: " . $output;
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 			$res = $np->check_threshold(check => $up) if (defined($np->threshold));
 			$res = UNKNOWN if ($res == OK && $unknown);
 		}
@@ -4695,7 +4695,7 @@ sub cluster_runtime_info
 			foreach my $vm (@$vm_views) {
 				$up += $vm->get_property('runtime.powerState')->val eq "poweredOn";
 			}
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, threshold => $np->threshold);
 			$output = $up . "/" . @$vm_views . " VMs up";
 		}
 		else


### PR DESCRIPTION
Hi,

according to the Nagios plugin guidelines

https://nagios-plugins.org/doc/guidelines.html#AEN200

the unit of measurement field MUST be empty for ordinary numbers, such as the number of VMs currently running.

The check should not die if not running VM is found. In a large cluster this can be perfectly normal if e.g. a host just exited maintenance mode.

Finally I removed the dependancy of Net::SSL again as this implementation is broken in many ways. Either leave it to the underlying VMware module to include the "right" module or use IO::Socket::SSL right away.

Thanks,

Christopher